### PR TITLE
fixed bug in ReAPI check

### DIFF
--- a/addons/amxmodx/scripting/next21_kill_assist.sma
+++ b/addons/amxmodx/scripting/next21_kill_assist.sma
@@ -11,7 +11,7 @@
 	#define client_disconnected client_disconnect
 #endif
 
-#if REAPI_VERSION_MAJOR < 5 && REAPI_VERSION_MINOR < 3
+#if REAPI_VERSION_MAJOR < 5 || (REAPI_VERSION_MAJOR == 5 && REAPI_VERSION_MINOR < 3)
 	#error You must be update ReAPI to 5.3.x or higher
 #endif
 

--- a/addons/amxmodx/scripting/next21_kill_assist.sma
+++ b/addons/amxmodx/scripting/next21_kill_assist.sma
@@ -11,8 +11,8 @@
 	#define client_disconnected client_disconnect
 #endif
 
-#if REAPI_VERSION < 52121
-	#error This plugin supports ReAPI >=5.2.0.121
+#if REAPI_VERSION_MAJOR < 5 && REAPI_VERSION_MINOR < 3
+	#error You must be update ReAPI to 5.3.x or higher
 #endif
 
 //#define DEBUG


### PR DESCRIPTION
current version of ReAPI is 5.26.1 defined as REAPI_VERSION 5261 wich is smaller than #if REAPI_VERSION < 52121

because of this, the plugin cant be compiled on newer reapi version